### PR TITLE
fix(appConfig) Update carto API url

### DIFF
--- a/example/transportation/config.js
+++ b/example/transportation/config.js
@@ -1,6 +1,6 @@
 const appConfig = {
-  carto_user: 'cpp',
-  carto_domain: 'cartoprod.capitalplanning.nyc',
+  carto_user: 'data',
+  carto_domain: 'carto.planninglabs.nyc',
 };
 
 export const mapLayers = {


### PR DESCRIPTION
I updated this to match https://capitalplanning.nyc.gov, because the current routes were throwing a 502 error. There might be a better testing/example API to hit instead.